### PR TITLE
Change font-size for .debuginfo .content

### DIFF
--- a/eliteshell.css
+++ b/eliteshell.css
@@ -345,7 +345,7 @@ div.multi-selector.hover-bubble.anchor-right {
     right: 5px;
     width: 390px;
     text-transform: lowercase;
-    font-size: small;
+    font-size: .80rem;
     text-align: left;
     color: #0c0;
     border-top: 2px solid #0c0;


### PR DESCRIPTION
The debuginfo is slightly larger than the box it's surrounded in, this uses 80% of the value of the body font-size (19 px * 0.80 = 15.2 px) to wrap the text in. Scales nicely.